### PR TITLE
add travis support for basic linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - "2.7"
   - "3.5"
 install:
-  - "pip install -r audio/requirements.txt"
-  - "pip install -r ibm_cloud_functions/requirements.txt"
   - "pip install flake8"
 script:
  - flake8 . --ignore E501,F841

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 install:
   - "pip install flake8"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install:
+  - "pip install -r audio/requirements.txt"
+  - "pip install -r ibm_cloud_functions/requirements.txt"
+  - "pip install flake8"
+script:
+ - flake8 . --ignore E501,F841

--- a/audio/detect_hotword.py
+++ b/audio/detect_hotword.py
@@ -1,9 +1,13 @@
-import snowboydecoder
 import sys
 import signal
+
+import snowboydecoder
+
 import record_audio
 
+
 interrupted = False
+
 
 def signal_handler(signal, frame):
     global interrupted
@@ -14,16 +18,19 @@ def interrupt_callback():
     global interrupted
     return interrupted
 
+
 def detected_callback():
     print("Hotword Detected...")
     print("record and submit sbsequent audio to watson speech to text")
     detector.terminate()
-    record_audio.listen_for_speech()    
+    record_audio.listen_for_speech()
+
 
 if len(sys.argv) == 1:
     print("Error: need to specify model name")
     print("Usage: python demo.py your.model")
     sys.exit(-1)
+
 
 model = sys.argv[1]
 
@@ -34,5 +41,3 @@ signal.signal(signal.SIGINT, signal_handler)
 detector = snowboydecoder.HotwordDetector(model, sensitivity=0.5)
 print('Listening... Press Ctrl+C to exit')
 detector.start(detected_callback=detected_callback, interrupt_check=interrupt_callback, sleep_time=0.03)
-
-

--- a/audio/record_audio.py
+++ b/audio/record_audio.py
@@ -36,7 +36,7 @@ def audio_int(num_samples=50):
         is the avg of the 20% largest intensities recorded.
     """
 
-    print "Getting intensity values from mic."
+    print("Getting intensity values from mic.")
     p = pyaudio.PyAudio()
 
     stream = p.open(format=FORMAT,
@@ -49,8 +49,7 @@ def audio_int(num_samples=50):
               for x in range(num_samples)]
     values = sorted(values, reverse=True)
     r = sum(values[:int(num_samples * 0.2)]) / int(num_samples * 0.2)
-    print " Finished "
-    print " Average audio intensity is ", r
+    print("Average audio intensity is: " + r)
     stream.close()
     p.terminate()
     return r
@@ -74,7 +73,7 @@ def listen_for_speech(threshold=THRESHOLD, num_phrases=1):
                     input=True,
                     frames_per_buffer=CHUNK)
 
-    print "* Listening mic. "
+    print("* Listening mic. ")
     audio2send = []
     cur_data = ''  # current chunk  of audio data
     rel = RATE / CHUNK
@@ -88,15 +87,15 @@ def listen_for_speech(threshold=THRESHOLD, num_phrases=1):
         slid_win.append(math.sqrt(abs(audioop.avg(cur_data, 4))))
         if(sum([x > THRESHOLD for x in slid_win]) > 0):
             if(not started):
-                print "Starting record of phrase"
+                print("Starting record of phrase")
                 started = True
             audio2send.append(cur_data)
         elif (started is True):
-            print "Finished"
+            print("Finished")
             # The limit was reached, finish capture and deliver.
             save_speech(list(prev_audio) + audio2send, p)
             result = transcribe_audio('speech.wav')
-            print result
+            print(result)
             text = result['data']
             print("Text: " + text + "\n")
             started = False
@@ -104,7 +103,7 @@ def listen_for_speech(threshold=THRESHOLD, num_phrases=1):
             prev_audio = deque(maxlen=0.5 * rel)
             audio2send = []
             n -= 1
-    print "* Done recording"
+    print("* Done recording")
     stream.close()
     p.terminate()
 

--- a/audio/record_audio.py
+++ b/audio/record_audio.py
@@ -112,7 +112,7 @@ def listen_for_speech(threshold=THRESHOLD, num_phrases=1):
 
 def transcribe_audio(path_to_audio_file):
     encoded_audio = open('speech.wav', 'r').read().encode("base64")
-    // TODO: use watson speech to text service
+    # TODO: use watson speech to text service
 
 
 def save_speech(data, p):

--- a/audio/record_audio.py
+++ b/audio/record_audio.py
@@ -133,5 +133,4 @@ def save_speech(data, p):
 
 if(__name__ == '__main__'):
     listen_for_speech()  # listen to mic.
-    # print stt_google_wav('hello.flac')  # translate audio file
     # audio_int()  # To measure your mic levels

--- a/audio/requirements.txt
+++ b/audio/requirements.txt
@@ -1,1 +1,2 @@
 PyAudio==0.2.9
+snowboy

--- a/ibm_cloud_functions/iot-pub.py
+++ b/ibm_cloud_functions/iot-pub.py
@@ -1,11 +1,11 @@
 import requests
 
 
-def main(dict):
-    iot_org_id = dict['iot_org_id']
-    device_id = dict['device_id']
-    device_type = dict['device_type']
-    api_token = dict['api_token']
-    classes = [nlc_class for nlc_class in dict['msg']['classes'] if nlc_class['confidence'] > 0.1]
+def main(iot_obj):
+    iot_org_id = iot_obj['iot_org_id']
+    device_id = iot_obj['device_id']
+    device_type = iot_obj['device_type']
+    api_token = iot_obj['api_token']
+    classes = [nlc_class for nlc_class in iot_obj['msg']['classes'] if nlc_class['confidence'] > 0.1]
     requests.post('http://' + iot_org_id + '.messaging.internetofthings.ibmcloud.com:1883/api/v0002/device/types/' + device_type + '/devices/' + device_id + '/events/query', headers={'Content-Type': 'application/json'}, json=classes, auth=('use-token-auth', api_token))
-    return {'msg': dict['msg']['text']}
+    return {'msg': iot_obj['msg']['text']}

--- a/ibm_cloud_functions/iot-pub.py
+++ b/ibm_cloud_functions/iot-pub.py
@@ -1,5 +1,5 @@
-import sys
 import requests
+
 
 def main(dict):
     iot_org_id = dict['iot_org_id']
@@ -7,5 +7,5 @@ def main(dict):
     device_type = dict['device_type']
     api_token = dict['api_token']
     classes = [nlc_class for nlc_class in dict['msg']['classes'] if nlc_class['confidence'] > 0.1]
-    r = requests.post('http://' + iot_org_id + '.messaging.internetofthings.ibmcloud.com:1883/api/v0002/device/types/' + device_type + '/devices/' + device_id + '/events/query', headers={'Content-Type': 'application/json'}, json=classes, auth=('use-token-auth', api_token))
+    requests.post('http://' + iot_org_id + '.messaging.internetofthings.ibmcloud.com:1883/api/v0002/device/types/' + device_type + '/devices/' + device_id + '/events/query', headers={'Content-Type': 'application/json'}, json=classes, auth=('use-token-auth', api_token))
     return {'msg': dict['msg']['text']}

--- a/ibm_cloud_functions/iot-pub.py
+++ b/ibm_cloud_functions/iot-pub.py
@@ -1,10 +1,11 @@
 import sys
 import requests
+
 def main(dict):
     iot_org_id = dict['iot_org_id']
     device_id = dict['device_id']
     device_type = dict['device_type']
     api_token = dict['api_token']
     classes = [nlc_class for nlc_class in dict['msg']['classes'] if nlc_class['confidence'] > 0.1]
-    r = requests.post('http://' + iot_org_id + '.messaging.internetofthings.ibmcloud.com:1883/api/v0002/device/types/' + device_type '/devices/' + device_id + '/events/query', headers={'Content-Type': 'application/json'}, json=classes, auth=('use-token-auth', api_token))
+    r = requests.post('http://' + iot_org_id + '.messaging.internetofthings.ibmcloud.com:1883/api/v0002/device/types/' + device_type + '/devices/' + device_id + '/events/query', headers={'Content-Type': 'application/json'}, json=classes, auth=('use-token-auth', api_token))
     return {'msg': dict['msg']['text']}

--- a/ibm_cloud_functions/requirements.txt
+++ b/ibm_cloud_functions/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
There were at least two syntax errors that should **not** have existed in a published pattern. A simple CI job that performs basic linting is usually a requirement for a code pattern. 

This PR fixes the aforementioned syntax errors, adds travis support to call a linting job (flake8) and modifies the code base to be flake8 compliant (ignoring long lines), and py3 friendly