### PR TITLE
Set a resonable limit on Python max-line-length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install:
   - "pip install flake8"
 script:
- - flake8 . --ignore E501,F841
+ - flake8 . --exclude=./audio/snowboy --ignore=F841 --max-line-length=127 --show-source

--- a/ibm_cloud_functions/iot-pub.py
+++ b/ibm_cloud_functions/iot-pub.py
@@ -1,9 +1,11 @@
 import requests
+
+
 def main(iot_obj):
-    iot_org_id = iot_obj['iot_org_id']
-    device_id = iot_obj['device_id']
-    device_type = iot_obj['device_type']
-    api_token = iot_obj['api_token']
+    url = ('http://{iot_org_id}.messaging.internetofthings.ibmcloud.com:1883/api/v0002/'
+           'device/types/{device_type}/devices/{device_id}/events/query').format(**iot_obj)
+    headers = {'Content-Type': 'application/json'}
+    auth = ('use-token-auth', iot_obj['api_token'])
     payload = {"d": iot_obj['msg']}
-    requests.post('http://' + iot_org_id + '.messaging.internetofthings.ibmcloud.com:1883/api/v0002/device/types/' + device_type + '/devices/' + device_id + '/events/query', headers={'Content-Type': 'application/json'}, json=payload, auth=('use-token-auth', api_token))
+    requests.post(url, headers=headers, json=payload, auth=auth)
     return {"msg": payload}


### PR DESCRIPTION
The GitHub editor is 127 chars wide so this limit allows folks to read our code on GitHub without having to scroll to the right and left.  Show source gives contributors a few lines of context to speed up their bug fixing.

* flake8 . --exclude=./audio/snowboy  # this repo has 184 flake8 issues to fix
* Simplify url creation via str.format(**dict)